### PR TITLE
add dependency repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Via Gradle
 repositories {
     mavenCentral()
     maven { url 'https://raw.github.com/nohana/Laevatein/master/repository/' }
+    maven { url 'https://raw.github.com/nohana/Amalgam/master/amalgam/repository/' }
+    maven { url 'https://raw.github.com/KeithYokoma/CompoundContainers/master/repository/' }
+    maven { url 'https://raw.github.com/mixi-inc/Android-Device-Compatibility/master/repository/' }
 }
 android {
     dependencies {


### PR DESCRIPTION
- Laevateinが依存しているモジュールのmaven repositoryも記述しないと依存解決ができなかったのでREADMEに追記しました。
