### PR TITLE
remove needless branch

### DIFF
--- a/laevatein/src/main/java/com/laevatein/MimeType.java
+++ b/laevatein/src/main/java/com/laevatein/MimeType.java
@@ -72,8 +72,6 @@ public enum MimeType {
         for (String extension : mExtensions) {
             if (extension.equals(type)) {
                 return true;
-            } else if (type != null) {
-                return false;
             }
             String path = PhotoMetadataUtils.getPath(resolver, uri);
             if (path != null && path.toLowerCase(Locale.US).endsWith(extension)) {


### PR DESCRIPTION
不要な条件判定があったため削除しました。
## 背景

セットmExtenstionsの中身がjpg,jpegであり、かつUIで選択した画像の形式がjpegだった場合に、L75の条件に該当してfalseを返してしまいます。
結果、本来選択できる画像にも関わらず「選択できない形式です」というダイアログが表示されました。
