### PR TITLE
fix for support support-library v22

### DIFF
--- a/laevatein/src/main/java/com/laevatein/internal/misc/ui/FragmentUtils.java
+++ b/laevatein/src/main/java/com/laevatein/internal/misc/ui/FragmentUtils.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Parcelable;
 import android.support.v4.app.Fragment;
+import android.view.View;
 
 /**
  * @author KeithYokoma
@@ -39,5 +40,13 @@ public final class FragmentUtils {
         Activity activity = fragment.getActivity();
         Intent intent = activity.getIntent();
         return intent.getBooleanExtra(key, fallback);
+    }
+
+    public static View findViewById(Fragment fragment, int id) {
+        View view = fragment.getView().findViewById(id);
+        if(view == null){
+            view = fragment.getView();
+        }
+        return view;
     }
 }

--- a/laevatein/src/main/java/com/laevatein/internal/ui/helper/AlbumListViewHelper.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/helper/AlbumListViewHelper.java
@@ -15,19 +15,20 @@
  */
 package com.laevatein.internal.ui.helper;
 
-import com.amalgam.os.HandlerUtils;
-import com.laevatein.R;
-import com.laevatein.internal.entity.Album;
-import com.laevatein.internal.entity.AlbumViewResources;
-import com.laevatein.internal.ui.AlbumListFragment;
-import com.laevatein.internal.ui.adapter.DevicePhotoAlbumAdapter;
-
 import android.database.Cursor;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.widget.CursorAdapter;
 import android.widget.AdapterView;
 import android.widget.ListView;
+
+import com.amalgam.os.HandlerUtils;
+import com.laevatein.R;
+import com.laevatein.internal.entity.Album;
+import com.laevatein.internal.entity.AlbumViewResources;
+import com.laevatein.internal.misc.ui.FragmentUtils;
+import com.laevatein.internal.ui.AlbumListFragment;
+import com.laevatein.internal.ui.adapter.DevicePhotoAlbumAdapter;
 
 /**
  * @author KeithYokoma
@@ -41,13 +42,13 @@ public final class AlbumListViewHelper {
     }
 
     public static void setUpListView(Fragment fragment, AdapterView.OnItemClickListener listener, AlbumViewResources resources) {
-        ListView listView = (ListView) fragment.getView().findViewById(R.id.l_list_album);
+        ListView listView = (ListView) FragmentUtils.findViewById(fragment, R.id.l_list_album);
         listView.setOnItemClickListener(listener);
         listView.setAdapter(new DevicePhotoAlbumAdapter(fragment.getActivity(), null, resources));
     }
 
     public static void setCursor(Fragment fragment, Cursor cursor) {
-        ListView listView = (ListView) fragment.getView().findViewById(R.id.l_list_album);
+        ListView listView = (ListView) FragmentUtils.findViewById(fragment, R.id.l_list_album);
         CursorAdapter adapter = (CursorAdapter) listView.getAdapter();
         adapter.swapCursor(cursor);
     }
@@ -74,7 +75,7 @@ public final class AlbumListViewHelper {
     }
 
     public static void setCheckedState(Fragment fragment, int position) {
-        ListView listView = (ListView) fragment.getView().findViewById(R.id.l_list_album);
+        ListView listView = (ListView) FragmentUtils.findViewById(fragment, R.id.l_list_album);
         listView.setItemChecked(position, true);
     }
 }

--- a/laevatein/src/main/java/com/laevatein/internal/ui/helper/SelectedCountViewHelper.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/helper/SelectedCountViewHelper.java
@@ -1,13 +1,13 @@
 package com.laevatein.internal.ui.helper;
 
+import android.view.View;
+import android.widget.TextView;
+
 import com.laevatein.R;
 import com.laevatein.internal.entity.ViewResourceSpec;
 import com.laevatein.internal.misc.ui.FragmentUtils;
 import com.laevatein.internal.ui.PhotoSelectionActivity;
 import com.laevatein.internal.ui.SelectedCountFragment;
-
-import android.view.View;
-import android.widget.TextView;
 
 /**
  * @author KeithYokoma
@@ -21,7 +21,7 @@ public final class SelectedCountViewHelper {
     }
 
     public static void setUpCountView(final SelectedCountFragment fragment) {
-        View view = fragment.getView().findViewById(R.id.l_container_count_view);
+        View view = FragmentUtils.findViewById(fragment, R.id.l_container_count_view);
         TextView label = (TextView) fragment.getView().findViewById(R.id.l_label_selected_count);
         ViewResourceSpec spec = FragmentUtils.getIntentParcelableExtra(fragment, PhotoSelectionActivity.EXTRA_VIEW_SPEC);
         view.setBackgroundResource(spec.getCountViewResources().getBackgroundColorResource());


### PR DESCRIPTION
fix to use wrapper method when we call "Fragment#getView#findViewById" to get root view of fragment.