### PR TITLE
fix selecting bug

### DIFF
--- a/laevatein/src/main/java/com/laevatein/internal/ui/helper/PreviewHelper.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/helper/PreviewHelper.java
@@ -102,7 +102,7 @@ public final class PreviewHelper {
                 UncapableCause cause = PhotoMetadataUtils
                         .isAcceptable(activity, spec, currentUri);
                 int currentCount = activity.getStateHolder().getChechedCount();
-                if (currentCount + 1 > spec.getMaxSelectable()) {
+                if (!activity.getStateHolder().isChecked(currentUri) && currentCount + 1 > spec.getMaxSelectable()) {
                     cause = UncapableCause.OVER_COUNT;
                 }
                 if (cause == null) {


### PR DESCRIPTION
以下の不具合を修正しました
・画像を上限枚数まで選択した後に選択していない画像の詳細画面を表示し、横スワイプで選択中の画像を表示すると上限を超えている旨のエラーが表示され選択が解除される