### PR TITLE
Change Picasso's resize() function to fit()

### DIFF
--- a/laevatein/src/main/java/com/laevatein/internal/ui/PreviewFragment.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/PreviewFragment.java
@@ -49,8 +49,7 @@ public class PreviewFragment extends Fragment {
         ImageViewTouch image = getView().findViewById(mViewResources.getImageViewId());
         image.setDisplayType(ImageViewTouchBase.DisplayType.FIT_TO_SCREEN);
         Uri uri = getArguments().getParcelable(ARGS_URI);
-        Point size = PhotoMetadataUtils.getBitmapSize(getActivity().getContentResolver(), uri, getActivity());
-        Picasso.with(getActivity()).load(uri).priority(Picasso.Priority.HIGH).resize(size.x, size.y).centerInside().into(image);
+        Picasso.with(getActivity()).load(uri).priority(Picasso.Priority.HIGH).fit().centerInside().into(image);
     }
 
     public void resetView() {

--- a/laevatein/src/main/java/com/laevatein/internal/ui/adapter/AlbumPhotoAdapter.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/adapter/AlbumPhotoAdapter.java
@@ -85,7 +85,7 @@ public class AlbumPhotoAdapter extends RecyclerViewCursorAdapter<AlbumPhotoAdapt
             holder.thumbnail.setImageResource(R.drawable.l_ic_capture);
         } else {
             Picasso.with(mContext).load(item.buildContentUri())
-                    .resizeDimen(R.dimen.l_gridItemImageWidth, R.dimen.l_gridItemImageHeight)
+                    .fit()
                     .centerCrop()
                     .into(holder.thumbnail);
         }

--- a/laevatein/src/main/java/com/laevatein/internal/ui/adapter/SelectedPhotoAdapter.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/adapter/SelectedPhotoAdapter.java
@@ -25,7 +25,6 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.ImageView;
 
-import com.laevatein.R;
 import com.laevatein.internal.entity.ItemViewResources;
 import com.laevatein.internal.model.SelectedUriCollection;
 import com.laevatein.internal.ui.helper.SelectedGridViewHelper;
@@ -35,9 +34,9 @@ import java.util.List;
 
 /**
  * @author KeithYokoma
- * @since 2014/03/27
  * @version 1.0.0
  * @hide
+ * @since 2014/03/27
  */
 public class SelectedPhotoAdapter extends RecyclerView.Adapter<SelectedPhotoAdapter.ViewHolder> {
     public static final String TAG = SelectedPhotoAdapter.class.getSimpleName();
@@ -73,7 +72,7 @@ public class SelectedPhotoAdapter extends RecyclerView.Adapter<SelectedPhotoAdap
             }
         });
         Picasso.with(mContext).load(uri)
-                .resizeDimen(R.dimen.l_gridItemImageWidth, R.dimen.l_gridItemImageHeight)
+                .fit()
                 .centerCrop()
                 .into(holder.thumbnail);
     }

--- a/laevatein/src/main/java/com/laevatein/internal/utils/PhotoMetadataUtils.java
+++ b/laevatein/src/main/java/com/laevatein/internal/utils/PhotoMetadataUtils.java
@@ -15,7 +15,6 @@
  */
 package com.laevatein.internal.utils;
 
-import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
@@ -25,7 +24,6 @@ import android.net.Uri;
 import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.support.media.ExifInterface;
-import android.util.DisplayMetrics;
 import android.util.Log;
 
 import com.amalgam.database.CursorUtils;
@@ -56,27 +54,6 @@ public final class PhotoMetadataUtils {
     public static int getPixelsCount(ContentResolver resolver, Uri uri) {
         Point size = getBitmapBound(resolver, uri);
         return size.x * size.y;
-    }
-
-    public static Point getBitmapSize(ContentResolver resolver, Uri uri, Activity activity) {
-        Point imageSize = getBitmapBound(resolver, uri);
-        int w = imageSize.x;
-        int h = imageSize.y;
-        if (PhotoMetadataUtils.shouldRotate(resolver, uri)) {
-            w = imageSize.y;
-            h = imageSize.x;
-        }
-        if (h == 0) return new Point(MAX_WIDTH, MAX_WIDTH);
-        DisplayMetrics metrics = new DisplayMetrics();
-        activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
-        float screenWidth = (float) metrics.widthPixels;
-        float screenHeight = (float) metrics.heightPixels;
-        float widthScale = screenWidth / w;
-        float heightScale = screenHeight / h;
-        if (widthScale > heightScale) {
-            return new Point((int) (w * widthScale), (int) (h * heightScale));
-        }
-        return new Point((int) (w * widthScale), (int) (h * heightScale));
     }
 
     private static Point getBitmapBound(ContentResolver resolver, Uri uri) {

--- a/laevatein/src/main/res/values/dimens.xml
+++ b/laevatein/src/main/res/values/dimens.xml
@@ -2,12 +2,5 @@
 <resources>
     <!-- for drawers -->
     <dimen name="l_drawerMenuWidth">280dp</dimen>
-
-    <!-- for grid views -->
-    <dimen name="l_gridItemImageWidth">48dp</dimen>
-    <dimen name="l_gridItemImageHeight">48dp</dimen>
-    <dimen name="l_gridItemSpacing">8dp</dimen>
-    <dimen name="l_gridPadding">8dp</dimen>
-
     <dimen name="grid_spacing">2dp</dimen>
 </resources>


### PR DESCRIPTION
## Overview
Change Picasso's resize() function to fit()

Picasso.fit()
```
  /**
   * Attempt to resize the image to fit exactly into the target {@link ImageView}'s bounds. This
   * will result in delayed execution of the request until the {@link ImageView} has been laid out.
   * <p>
   * <em>Note:</em> This method works only when your target is an {@link ImageView}.
   */
  public RequestCreator fit() {
    deferred = true;
    return this;
  }
```

## Comparison
Nexus 5X(1080 x 1920 420api)

||Before(resize)|After(fit)|
|:--:|:--:|:--:|
| grid |![before_grid resize](https://user-images.githubusercontent.com/3312886/33594201-4dce1986-d9d6-11e7-97a1-d35b1ae864ae.png)|![after_grid fit](https://user-images.githubusercontent.com/3312886/33594206-55826e7a-d9d6-11e7-83ef-a0140aad9974.png)|
|preview(max scale)|![before resize](https://user-images.githubusercontent.com/3312886/33594313-d9ddd556-d9d6-11e7-840c-17c2f79699f3.png)|![after fit](https://user-images.githubusercontent.com/3312886/33594325-e19eb3aa-d9d6-11e7-9e3c-172132d43fdb.png)|