### PR TITLE
Use Glide instead of Picasso

### DIFF
--- a/laevatein/build.gradle
+++ b/laevatein/build.gradle
@@ -27,7 +27,11 @@ dependencies {
     implementation "com.android.support:support-annotations:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation "com.android.support:exifinterface:${supportLibraryVersion}"
-    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation ("com.github.bumptech.glide:glide:4.4.0") {
+        exclude group: 'com.android.support', module: 'support-fragment'
+    }
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.4.0'
+    // implementation 'com.squareup.picasso:picasso:2.5.2'
     implementation 'it.sephiroth.android.library.imagezoom:library:1.0.4'
     implementation 'jp.co.nohana:Amalgam:0.4.0@aar'
     implementation 'jp.mixi:AndroidDeviceCompatibility:1.0.0@aar'

--- a/laevatein/build.gradle
+++ b/laevatein/build.gradle
@@ -31,7 +31,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-fragment'
     }
     annotationProcessor 'com.github.bumptech.glide:compiler:4.4.0'
-    // implementation 'com.squareup.picasso:picasso:2.5.2'
     implementation 'it.sephiroth.android.library.imagezoom:library:1.0.4'
     implementation 'jp.co.nohana:Amalgam:0.4.0@aar'
     implementation 'jp.mixi:AndroidDeviceCompatibility:1.0.0@aar'

--- a/laevatein/src/main/java/com/laevatein/LaevateinGlideModule.java
+++ b/laevatein/src/main/java/com/laevatein/LaevateinGlideModule.java
@@ -1,0 +1,8 @@
+package com.laevatein;
+
+import com.bumptech.glide.annotation.GlideModule;
+import com.bumptech.glide.module.AppGlideModule;
+
+@GlideModule
+public final class LaevateinGlideModule extends AppGlideModule {
+}

--- a/laevatein/src/main/java/com/laevatein/internal/ui/PreviewFragment.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/PreviewFragment.java
@@ -1,6 +1,5 @@
 package com.laevatein.internal.ui;
 
-import android.graphics.Point;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -9,9 +8,9 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.amalgam.os.BundleUtils;
+import com.bumptech.glide.Priority;
+import com.laevatein.GlideApp;
 import com.laevatein.internal.entity.PreviewViewResources;
-import com.laevatein.internal.utils.PhotoMetadataUtils;
-import com.squareup.picasso.Picasso;
 
 import it.sephiroth.android.library.imagezoom.ImageViewTouch;
 import it.sephiroth.android.library.imagezoom.ImageViewTouchBase;
@@ -49,7 +48,7 @@ public class PreviewFragment extends Fragment {
         ImageViewTouch image = getView().findViewById(mViewResources.getImageViewId());
         image.setDisplayType(ImageViewTouchBase.DisplayType.FIT_TO_SCREEN);
         Uri uri = getArguments().getParcelable(ARGS_URI);
-        Picasso.with(getActivity()).load(uri).priority(Picasso.Priority.HIGH).fit().centerInside().into(image);
+        GlideApp.with(getActivity()).load(uri).priority(Priority.HIGH).fitCenter().centerInside().into(image);
     }
 
     public void resetView() {

--- a/laevatein/src/main/java/com/laevatein/internal/ui/adapter/AlbumPhotoAdapter.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/adapter/AlbumPhotoAdapter.java
@@ -25,12 +25,14 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.ImageView;
 
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.RequestOptions;
+import com.laevatein.GlideApp;
 import com.laevatein.R;
 import com.laevatein.internal.entity.Item;
 import com.laevatein.internal.entity.ItemViewResources;
 import com.laevatein.internal.model.SelectedUriCollection;
 import com.laevatein.internal.ui.helper.PhotoGridViewHelper;
-import com.squareup.picasso.Picasso;
 
 /**
  * @author KeithYokoma
@@ -84,8 +86,8 @@ public class AlbumPhotoAdapter extends RecyclerViewCursorAdapter<AlbumPhotoAdapt
         if (item.isCapture()) {
             holder.thumbnail.setImageResource(R.drawable.l_ic_capture);
         } else {
-            Picasso.with(mContext).load(item.buildContentUri())
-                    .fit()
+            GlideApp.with(mContext).load(item.buildContentUri())
+                    .fitCenter()
                     .centerCrop()
                     .into(holder.thumbnail);
         }

--- a/laevatein/src/main/java/com/laevatein/internal/ui/adapter/SelectedPhotoAdapter.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/adapter/SelectedPhotoAdapter.java
@@ -25,10 +25,10 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.ImageView;
 
+import com.laevatein.GlideApp;
 import com.laevatein.internal.entity.ItemViewResources;
 import com.laevatein.internal.model.SelectedUriCollection;
 import com.laevatein.internal.ui.helper.SelectedGridViewHelper;
-import com.squareup.picasso.Picasso;
 
 import java.util.List;
 
@@ -71,8 +71,8 @@ public class SelectedPhotoAdapter extends RecyclerView.Adapter<SelectedPhotoAdap
                 SelectedGridViewHelper.callCheckStateListener(mListener);
             }
         });
-        Picasso.with(mContext).load(uri)
-                .fit()
+        GlideApp.with(mContext).load(uri)
+                .fitCenter()
                 .centerCrop()
                 .into(holder.thumbnail);
     }


### PR DESCRIPTION
## Overview
Use Glide instead of Picasso.

This PR implements it using Glide Generated API.
If do not use this API, it will be as follows, but since it is not intuitive, I use Generated API.
https://github.com/nohana/Laevatein/blob/9359885155a3e34839addb539f6eba59400a3a38/laevatein/src/main/java/com/laevatein/internal/ui/adapter/AlbumPhotoAdapter.java#L89-L92

↓↓↓↓↓↓↓↓↓

```
RequestOptions options = new RequestOptions();
options.fitCenter()
options.centerCrop()

Glide.with(mContext).load(item.buildContentUri())
       .apply(options)
       .into(holder.thumbnail);
```

## Other
Since `Glide v4.4` depends, `support-fragment:27.0.1`  is exclude.
https://github.com/nohana/Laevatein/blob/9359885155a3e34839addb539f6eba59400a3a38/laevatein/build.gradle#L31

## Links
Github https://github.com/bumptech/glide
Document https://bumptech.github.io/glide
GenerateAPI doc https://bumptech.github.io/glide/doc/generatedapi.html