### PR TITLE
FileUriExposedException occurs when take a picture at API Level 24 or later

### DIFF
--- a/laevatein/build.gradle
+++ b/laevatein/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 14

--- a/laevatein/build.gradle
+++ b/laevatein/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion "26.0.3"
 
     defaultConfig {
@@ -18,7 +18,7 @@ android {
     testOptions.unitTests.includeAndroidResources true
 }
 
-ext.supportLibraryVersion = '26.1.0'
+ext.supportLibraryVersion = '27.1.0'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/laevatein/build.gradle
+++ b/laevatein/build.gradle
@@ -27,13 +27,12 @@ dependencies {
     implementation "com.android.support:support-annotations:${supportLibraryVersion}"
     implementation "com.android.support:design:${supportLibraryVersion}"
     implementation "com.android.support:exifinterface:${supportLibraryVersion}"
-    implementation ("com.github.bumptech.glide:glide:4.4.0") {
+    implementation("com.github.bumptech.glide:glide:4.4.0") {
         exclude group: 'com.android.support', module: 'support-fragment'
     }
     annotationProcessor 'com.github.bumptech.glide:compiler:4.4.0'
     implementation 'it.sephiroth.android.library.imagezoom:library:1.0.4'
     implementation 'jp.co.nohana:Amalgam:0.4.0@aar'
-    implementation 'jp.mixi:AndroidDeviceCompatibility:1.0.0@aar'
 
     // Robolectric
     testImplementation 'junit:junit:4.12'

--- a/laevatein/src/main/AndroidManifest.xml
+++ b/laevatein/src/main/AndroidManifest.xml
@@ -1,10 +1,22 @@
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.laevatein">
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+
     <application android:allowBackup="true">
-        <activity android:name=".ui.PhotoSelectionActivity"/>
-        <activity android:name=".ui.ImagePreviewActivity"/>
+        <activity android:name=".ui.PhotoSelectionActivity" />
+        <activity android:name=".ui.ImagePreviewActivity" />
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="@string/l_file_provider_authorities"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/laevatein/src/main/java/com/laevatein/internal/loader/AlbumPhotoLoader.java
+++ b/laevatein/src/main/java/com/laevatein/internal/loader/AlbumPhotoLoader.java
@@ -15,9 +15,6 @@
  */
 package com.laevatein.internal.loader;
 
-import com.laevatein.internal.entity.Album;
-import com.laevatein.internal.entity.Item;
-
 import android.content.Context;
 import android.database.Cursor;
 import android.database.MatrixCursor;
@@ -26,17 +23,19 @@ import android.net.Uri;
 import android.provider.MediaStore;
 import android.support.v4.content.CursorLoader;
 
-import jp.mixi.compatibility.android.provider.MediaStoreCompat;
+import com.laevatein.internal.entity.Album;
+import com.laevatein.internal.entity.Item;
+import com.laevatein.internal.utils.MediaStoreUtils;
 
 /**
  * @author KeithYokoma
- * @since 2014/03/27
  * @version 1.0.0
  * @hide
+ * @since 2014/03/27
  */
 public class AlbumPhotoLoader extends CursorLoader {
     public static final String TAG = AlbumPhotoLoader.class.getSimpleName();
-    private static final String[] PROJECTION = { MediaStore.Images.Media._ID, MediaStore.Images.Media.DISPLAY_NAME };
+    private static final String[] PROJECTION = {MediaStore.Images.Media._ID, MediaStore.Images.Media.DISPLAY_NAME};
     private static final String ORDER_BY = MediaStore.Images.Media._ID + " DESC";
     private final boolean mEnableCapture;
 
@@ -54,17 +53,17 @@ public class AlbumPhotoLoader extends CursorLoader {
 
     public static CursorLoader newInstance(Context context, Album album, boolean capture) {
         return new AlbumPhotoLoader(context, MediaStore.Images.Media.EXTERNAL_CONTENT_URI, PROJECTION,
-                MediaStore.Images.Media.BUCKET_ID + " = ?", new String[]{ album.getId() }, ORDER_BY, capture);
+                MediaStore.Images.Media.BUCKET_ID + " = ?", new String[]{album.getId()}, ORDER_BY, capture);
     }
 
     @Override
     public Cursor loadInBackground() {
         Cursor result = super.loadInBackground();
-        if (!mEnableCapture || !MediaStoreCompat.hasCameraFeature(getContext())) {
+        if (!mEnableCapture || !MediaStoreUtils.hasCameraFeature(getContext())) {
             return result;
         }
         MatrixCursor dummy = new MatrixCursor(PROJECTION);
-        dummy.addRow(new Object[] { Item.ITEM_ID_CAPTURE, Item.ITEM_DISPLAY_NAME_CAPTURE });
-        return new MergeCursor(new Cursor[] { dummy, result });
+        dummy.addRow(new Object[]{Item.ITEM_ID_CAPTURE, Item.ITEM_DISPLAY_NAME_CAPTURE});
+        return new MergeCursor(new Cursor[]{dummy, result});
     }
 }

--- a/laevatein/src/main/java/com/laevatein/internal/ui/helper/PhotoGridViewHelper.java
+++ b/laevatein/src/main/java/com/laevatein/internal/ui/helper/PhotoGridViewHelper.java
@@ -41,13 +41,12 @@ import com.laevatein.internal.ui.adapter.AlbumPhotoAdapter;
 import com.laevatein.internal.ui.adapter.RecyclerViewCursorAdapter;
 import com.laevatein.internal.ui.widget.PhotoDecoration;
 import com.laevatein.internal.utils.ErrorViewUtils;
+import com.laevatein.internal.utils.MediaStoreUtils;
 import com.laevatein.ui.ImagePreviewActivity;
 import com.laevatein.ui.PhotoSelectionActivity;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import jp.mixi.compatibility.android.provider.MediaStoreCompat;
 
 /**
  * @author KeithYokoma
@@ -131,8 +130,8 @@ public final class PhotoGridViewHelper {
 
     public static void callCamera(Context context) {
         PhotoSelectionActivity activity = (PhotoSelectionActivity) context;
-        MediaStoreCompat compat = activity.getMediaStoreCompat();
-        String preparedUri = compat.invokeCameraCapture(activity, PhotoSelectionActivity.REQUEST_CODE_CAPTURE);
+        MediaStoreUtils utils = activity.getMediaStoreUtils();
+        String preparedUri = utils.invokeCameraCapture(activity, PhotoSelectionActivity.REQUEST_CODE_CAPTURE);
         activity.prepareCapture(preparedUri);
     }
 

--- a/laevatein/src/main/java/com/laevatein/internal/utils/ExifInterfaceUtils.java
+++ b/laevatein/src/main/java/com/laevatein/internal/utils/ExifInterfaceUtils.java
@@ -1,6 +1,6 @@
 package com.laevatein.internal.utils;
 
-import android.media.ExifInterface;
+import android.support.media.ExifInterface;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -11,8 +11,6 @@ import java.util.Date;
 import java.util.TimeZone;
 
 /**
- * Bug fixture for ExifInterface constructor.
- * <p>
  * This class is based on this source code.
  * https://github.com/mixi-inc/Android-Device-Compatibility/blob/master/AndroidDeviceCompatibility/src/main/java/jp/mixi/compatibility/android/media/ExifInterfaceCompat.java
  * <p>
@@ -21,7 +19,7 @@ import java.util.TimeZone;
  */
 public class ExifInterfaceUtils {
     public static final String TAG = ExifInterfaceUtils.class.getSimpleName();
-    public static final int EXIF_DEGREE_FALLBACK_VALUE = -1;
+    private static final int EXIF_DEGREE_FALLBACK_VALUE = -1;
 
     /**
      * Do not instantiate this class.
@@ -29,28 +27,10 @@ public class ExifInterfaceUtils {
     private ExifInterfaceUtils() {
     }
 
-    /**
-     * Creates new instance of {@link ExifInterface}.
-     * Original constructor won't check filename value, so if null value has been passed,
-     * the process will be killed because of SIGSEGV.
-     * Google Play crash report system cannot perceive this crash, so this method will throw {@link NullPointerException} when the filename is null.
-     *
-     * @param filename a JPEG filename.
-     * @return {@link ExifInterface} instance.
-     * @throws IOException something wrong with I/O.
-     */
-    public static final ExifInterface newInstance(String filename) throws IOException {
-        if (filename == null) throw new NullPointerException("filename should not be null");
-        return new ExifInterface(filename);
-    }
-
-    public static final Date getExifDateTime(String filepath) {
+    private static Date getExifDateTime(String filepath) {
         ExifInterface exif = null;
         try {
-            // ExifInterface does not check whether file path is null or not,
-            // so passing null file path argument to its constructor causing SIGSEGV.
-            // We should avoid such a situation by checking file path string.
-            exif = ExifInterfaceUtils.newInstance(filepath);
+            exif = new ExifInterface(filepath);
         } catch (IOException ex) {
             Log.e(TAG, "cannot read exif", ex);
             return null;
@@ -76,7 +56,7 @@ public class ExifInterfaceUtils {
      * @param filepath to get datetime
      * @return when a photo taken.
      */
-    public static final long getExifDateTimeInMillis(String filepath) {
+    public static long getExifDateTimeInMillis(String filepath) {
         Date datetime = getExifDateTime(filepath);
         if (datetime == null) {
             return -1;
@@ -90,13 +70,10 @@ public class ExifInterfaceUtils {
      * @param filepath to get exif.
      * @return exif orientation value
      */
-    public static final int getExifOrientation(String filepath) {
+    public static int getExifOrientation(String filepath) {
         ExifInterface exif = null;
         try {
-            // ExifInterface does not check whether file path is null or not,
-            // so passing null file path argument to its constructor causing SIGSEGV.
-            // We should avoid such a situation by checking file path string.
-            exif = ExifInterfaceUtils.newInstance(filepath);
+            exif = new ExifInterface(filepath);
         } catch (IOException ex) {
             Log.e(TAG, "cannot read exif", ex);
             return EXIF_DEGREE_FALLBACK_VALUE;

--- a/laevatein/src/main/java/com/laevatein/internal/utils/ExifInterfaceUtils.java
+++ b/laevatein/src/main/java/com/laevatein/internal/utils/ExifInterfaceUtils.java
@@ -1,0 +1,121 @@
+package com.laevatein.internal.utils;
+
+import android.media.ExifInterface;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * Bug fixture for ExifInterface constructor.
+ * <p>
+ * This class is based on this source code.
+ * https://github.com/mixi-inc/Android-Device-Compatibility/blob/master/AndroidDeviceCompatibility/src/main/java/jp/mixi/compatibility/android/media/ExifInterfaceCompat.java
+ * <p>
+ * License
+ * see: https://github.com/mixi-inc/Android-Device-Compatibility#license
+ */
+public class ExifInterfaceUtils {
+    public static final String TAG = ExifInterfaceUtils.class.getSimpleName();
+    public static final int EXIF_DEGREE_FALLBACK_VALUE = -1;
+
+    /**
+     * Do not instantiate this class.
+     */
+    private ExifInterfaceUtils() {
+    }
+
+    /**
+     * Creates new instance of {@link ExifInterface}.
+     * Original constructor won't check filename value, so if null value has been passed,
+     * the process will be killed because of SIGSEGV.
+     * Google Play crash report system cannot perceive this crash, so this method will throw {@link NullPointerException} when the filename is null.
+     *
+     * @param filename a JPEG filename.
+     * @return {@link ExifInterface} instance.
+     * @throws IOException something wrong with I/O.
+     */
+    public static final ExifInterface newInstance(String filename) throws IOException {
+        if (filename == null) throw new NullPointerException("filename should not be null");
+        return new ExifInterface(filename);
+    }
+
+    public static final Date getExifDateTime(String filepath) {
+        ExifInterface exif = null;
+        try {
+            // ExifInterface does not check whether file path is null or not,
+            // so passing null file path argument to its constructor causing SIGSEGV.
+            // We should avoid such a situation by checking file path string.
+            exif = ExifInterfaceUtils.newInstance(filepath);
+        } catch (IOException ex) {
+            Log.e(TAG, "cannot read exif", ex);
+            return null;
+        }
+
+        String date = exif.getAttribute(ExifInterface.TAG_DATETIME);
+        if (TextUtils.isEmpty(date)) {
+            return null;
+        }
+        try {
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
+            formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+            return formatter.parse(date);
+        } catch (ParseException e) {
+            Log.d(TAG, "failed to parse date taken", e);
+        }
+        return null;
+    }
+
+    /**
+     * Read exif info and get datetime value of the photo.
+     *
+     * @param filepath to get datetime
+     * @return when a photo taken.
+     */
+    public static final long getExifDateTimeInMillis(String filepath) {
+        Date datetime = getExifDateTime(filepath);
+        if (datetime == null) {
+            return -1;
+        }
+        return datetime.getTime();
+    }
+
+    /**
+     * Read exif info and get orientation value of the photo.
+     *
+     * @param filepath to get exif.
+     * @return exif orientation value
+     */
+    public static final int getExifOrientation(String filepath) {
+        ExifInterface exif = null;
+        try {
+            // ExifInterface does not check whether file path is null or not,
+            // so passing null file path argument to its constructor causing SIGSEGV.
+            // We should avoid such a situation by checking file path string.
+            exif = ExifInterfaceUtils.newInstance(filepath);
+        } catch (IOException ex) {
+            Log.e(TAG, "cannot read exif", ex);
+            return EXIF_DEGREE_FALLBACK_VALUE;
+        }
+
+        int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, EXIF_DEGREE_FALLBACK_VALUE);
+        if (orientation == EXIF_DEGREE_FALLBACK_VALUE) {
+            return 0;
+        }
+        // We only recognize a subset of orientation tag values.
+        switch (orientation) {
+            case ExifInterface.ORIENTATION_ROTATE_90:
+                return 90;
+            case ExifInterface.ORIENTATION_ROTATE_180:
+                return 180;
+            case ExifInterface.ORIENTATION_ROTATE_270:
+                return 270;
+            default:
+                return 0;
+        }
+    }
+}

--- a/laevatein/src/main/java/com/laevatein/internal/utils/ExifInterfaceUtils.java
+++ b/laevatein/src/main/java/com/laevatein/internal/utils/ExifInterfaceUtils.java
@@ -19,7 +19,6 @@ import java.util.TimeZone;
  */
 public class ExifInterfaceUtils {
     public static final String TAG = ExifInterfaceUtils.class.getSimpleName();
-    private static final int EXIF_DEGREE_FALLBACK_VALUE = -1;
 
     /**
      * Do not instantiate this class.
@@ -62,37 +61,5 @@ public class ExifInterfaceUtils {
             return -1;
         }
         return datetime.getTime();
-    }
-
-    /**
-     * Read exif info and get orientation value of the photo.
-     *
-     * @param filepath to get exif.
-     * @return exif orientation value
-     */
-    public static int getExifOrientation(String filepath) {
-        ExifInterface exif = null;
-        try {
-            exif = new ExifInterface(filepath);
-        } catch (IOException ex) {
-            Log.e(TAG, "cannot read exif", ex);
-            return EXIF_DEGREE_FALLBACK_VALUE;
-        }
-
-        int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, EXIF_DEGREE_FALLBACK_VALUE);
-        if (orientation == EXIF_DEGREE_FALLBACK_VALUE) {
-            return 0;
-        }
-        // We only recognize a subset of orientation tag values.
-        switch (orientation) {
-            case ExifInterface.ORIENTATION_ROTATE_90:
-                return 90;
-            case ExifInterface.ORIENTATION_ROTATE_180:
-                return 180;
-            case ExifInterface.ORIENTATION_ROTATE_270:
-                return 270;
-            default:
-                return 0;
-        }
     }
 }

--- a/laevatein/src/main/java/com/laevatein/internal/utils/MediaStoreUtils.java
+++ b/laevatein/src/main/java/com/laevatein/internal/utils/MediaStoreUtils.java
@@ -1,0 +1,340 @@
+package com.laevatein.internal.utils;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.os.Handler;
+import android.provider.MediaStore;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+
+/**
+ * Compatibility class for the issue of various implementations of camera feature.
+ * <p>
+ * This class is based on this source code.
+ * https://github.com/mixi-inc/Android-Device-Compatibility/blob/master/AndroidDeviceCompatibility/src/main/java/jp/mixi/compatibility/android/provider/MediaStoreCompat.java
+ * <p>
+ * License
+ * see: https://github.com/mixi-inc/Android-Device-Compatibility#license
+ */
+public class MediaStoreUtils {
+    public static final String TAG = MediaStoreUtils.class.getSimpleName();
+    private static final String MEDIA_FILE_NAME_FORMAT = "yyyyMMdd_HHmmss";
+    private static final String MEDIA_FILE_EXTENSION = ".jpg";
+    private static final String MEDIA_FILE_PREFIX = "IMG_";
+    private final String MEDIA_FILE_DIRECTORY;
+    private Context mContext;
+    private ContentObserver mObserver;
+    private ArrayList<PhotoContent> mRecentlyUpdatedPhotos;
+
+    /**
+     * Prepares to deal with various implementations of camera feature and {@link MediaStore}.
+     * You should call {@link MediaStoreUtils#destroy()} on destroying context.
+     *
+     * @param context a context
+     * @param handler a handler
+     */
+    public MediaStoreUtils(Context context, Handler handler) {
+        mContext = context;
+        MEDIA_FILE_DIRECTORY = context.getPackageName();
+        mObserver = new ContentObserver(handler) {
+            @Override
+            public void onChange(boolean selfChange) {
+                super.onChange(selfChange);
+                updateLatestPhotos();
+            }
+        };
+        mContext.getContentResolver().registerContentObserver(
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI, true, mObserver);
+    }
+
+    /**
+     * Checks whether the device has a camera feature or not.
+     *
+     * @param context a context to check for camera feature.
+     * @return true if the device has a camera feature. false otherwise.
+     */
+    public static final boolean hasCameraFeature(Context context) {
+        PackageManager pm = context.getApplicationContext().getPackageManager();
+        return pm.hasSystemFeature(PackageManager.FEATURE_CAMERA);
+    }
+
+    /**
+     * Invokes a camera capture activity.
+     *
+     * @param activity    the caller of the camera capture activity.
+     * @param requestCode activity result handling id.
+     * @return a file name to be saved as.
+     */
+    public String invokeCameraCapture(Activity activity, int requestCode) {
+        if (!hasCameraFeature(mContext)) return null;
+
+        File toSave = getOutputFileUri();
+        if (toSave == null) return null;
+
+        Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        intent.addCategory(Intent.CATEGORY_DEFAULT);
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(toSave));
+        intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, 1);
+        activity.startActivityForResult(intent, requestCode);
+        return toSave.toString();
+    }
+
+    /**
+     * Should be called on destroying context to dereference to the {@link ContentObserver}.
+     */
+    public void destroy() {
+        mContext.getContentResolver().unregisterContentObserver(mObserver);
+    }
+
+    /**
+     * @param data        the result {@link Intent} of a camera activity.
+     * @param preparedUri a prepared photo uri to fetch photo data.
+     * @return captured photo {@link Uri}
+     */
+    public Uri getCapturedPhotoUri(Intent data, String preparedUri) {
+        Uri captured = null;
+        if (data != null) {
+            captured = data.getData();
+            if (captured == null) data.getParcelableExtra(Intent.EXTRA_STREAM);
+        }
+
+        File prepared = new File(preparedUri.toString());
+        if (captured == null || captured.equals(Uri.fromFile(prepared))) {
+            captured = findPhotoFromRecentlyTaken(prepared);
+            if (captured == null) {
+                captured = storeImage(prepared);
+                prepared.delete();
+            } else {
+                // Found. Compare the destination path
+                // and delete app-private one if there is any copy outside of app-private directory.
+                String realPath = getPathFromUri(
+                        mContext.getContentResolver(), captured);
+                if (realPath != null) {
+                    if (!prepared.equals(new File(realPath))) prepared.delete();
+                }
+            }
+        }
+
+        return captured;
+    }
+
+    /**
+     * Deletes unnecessary files if exist.
+     *
+     * @param uri to delete.
+     */
+    public void cleanUp(String uri) {
+        File file = new File(uri.toString());
+        if (file.exists()) file.delete();
+    }
+
+    /**
+     * Obtains a captured photo file path from content {@link Uri} of a {@link MediaStore}
+     *
+     * @param resolver   a content resolver
+     * @param contentUri a content uri
+     * @return captured photo file path string
+     */
+    public static String getPathFromUri(ContentResolver resolver, Uri contentUri) {
+        final String dataColumn = MediaStore.MediaColumns.DATA;
+        Cursor cursor = null;
+        try {
+            cursor = resolver.query(contentUri, new String[]{dataColumn}, null, null, null);
+            if (cursor == null || !cursor.moveToFirst()) return null;
+
+            final int index = cursor.getColumnIndex(dataColumn);
+            return cursor.getString(index);
+        } finally {
+            if (cursor != null) cursor.close();
+        }
+    }
+
+    /**
+     * Copies file streams.
+     *
+     * @param is input stream
+     * @param os output stream
+     * @return the number of bytes.
+     * @throws IOException if something wrong with I/O.
+     */
+    public static long copyFileStream(FileInputStream is, FileOutputStream os)
+            throws IOException {
+        FileChannel srcChannel = null;
+        FileChannel destChannel = null;
+        try {
+            srcChannel = is.getChannel();
+            destChannel = os.getChannel();
+            return srcChannel.transferTo(0, srcChannel.size(), destChannel);
+        } finally {
+            if (srcChannel != null) srcChannel.close();
+            if (destChannel != null) destChannel.close();
+        }
+    }
+
+    /**
+     * Obtains file {@link Uri} that refers to a recently taken photo.
+     *
+     * @param file to search
+     * @return photo file uri.
+     */
+    private Uri findPhotoFromRecentlyTaken(File file) {
+        if (mRecentlyUpdatedPhotos == null)
+            updateLatestPhotos();
+
+        long filesize = file.length();
+        long taken = ExifInterfaceUtils.getExifDateTimeInMillis(file.getAbsolutePath());
+
+        int maxPoint = 0;
+        PhotoContent maxItem = null;
+        for (PhotoContent item : mRecentlyUpdatedPhotos) {
+            int point = 0;
+            if (item.size == filesize)
+                point++;
+            if (item.taken == taken)
+                point++;
+            if (point > maxPoint) {
+                maxPoint = point;
+                maxItem = item;
+            }
+        }
+        if (maxItem != null) {
+            generateThumbnails(maxItem.id);
+            return ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                    maxItem.id);
+        }
+
+        return null;
+    }
+
+    /**
+     * Stores a file to media store with photo orientation and date that taken.
+     *
+     * @param file to store
+     * @return a stored file uri
+     */
+    private Uri storeImage(File file) {
+        // store image to content provider
+        try {
+            // create parameters for Intent with filename
+            ContentValues values = new ContentValues();
+            values.put(MediaStore.Images.Media.TITLE, file.getName());
+            values.put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg");
+            values.put(MediaStore.Images.Media.DESCRIPTION, "mixi Photo");
+            values.put(MediaStore.Images.Media.ORIENTATION,
+                    ExifInterfaceUtils.getExifOrientation(file.getAbsolutePath()));
+            long date = ExifInterfaceUtils.getExifDateTimeInMillis(file.getAbsolutePath());
+            if (date != -1)
+                values.put(MediaStore.Images.Media.DATE_TAKEN, date);
+
+            Uri imageUri = mContext.getContentResolver().insert(
+                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values);
+
+            FileOutputStream fos = (FileOutputStream) mContext.getContentResolver().openOutputStream(
+                    imageUri);
+            FileInputStream fis = new FileInputStream(file);
+            copyFileStream(fis, fos);
+            fos.close();
+            fis.close();
+
+            generateThumbnails(ContentUris.parseId(imageUri));
+
+            return imageUri;
+        } catch (Exception e) {
+            Log.w(TAG, "cannot insert", e);
+            return null;
+        }
+    }
+
+    /**
+     * Request to update latest photos onto media store.
+     */
+    private void updateLatestPhotos() {
+        // retrieve the newest five images
+        Cursor c = MediaStore.Images.Media.query(mContext.getContentResolver(),
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI, new String[]{
+                        MediaStore.Images.ImageColumns._ID,
+                        MediaStore.Images.ImageColumns.DATE_TAKEN,
+                        MediaStore.Images.ImageColumns.SIZE,
+                }, null, null, MediaStore.Images.ImageColumns.DATE_ADDED + " DESC");
+        if (c != null) {
+            try {
+                int count = 0;
+                mRecentlyUpdatedPhotos = new ArrayList<PhotoContent>();
+                while (c.moveToNext()) {
+                    PhotoContent item = new PhotoContent();
+                    item.id = c.getLong(0);
+                    item.taken = c.getLong(1);
+                    item.size = c.getInt(2);
+                    mRecentlyUpdatedPhotos.add(item);
+                    if (++count > 5)
+                        break;
+                }
+            } finally {
+                c.close();
+            }
+        }
+    }
+
+    /**
+     * Create thumbnail images for a specified photo image.
+     *
+     * @param imageId referes to a photo image.
+     */
+    private void generateThumbnails(long imageId) {
+        try {
+            MediaStore.Images.Thumbnails.getThumbnail(mContext.getContentResolver(), imageId,
+                    MediaStore.Images.Thumbnails.MINI_KIND, null);
+        } catch (NullPointerException e) {
+            // some MediaStores throws NPE, just ignore the result
+        }
+    }
+
+    /**
+     * Make output file uri based on a external storage directory.
+     *
+     * @return a file
+     */
+    @TargetApi(Build.VERSION_CODES.FROYO)
+    private File getOutputFileUri() {
+        File extDir = new File(
+                Environment.getExternalStoragePublicDirectory(
+                        Environment.DIRECTORY_PICTURES),
+                MEDIA_FILE_DIRECTORY);
+
+        if (!extDir.exists()) {
+            if (!extDir.mkdirs()) return null;
+        }
+
+        String timeStamp = new SimpleDateFormat(MEDIA_FILE_NAME_FORMAT).format(new Date());
+        return new File(extDir.getPath() + File.separator +
+                MEDIA_FILE_PREFIX + timeStamp + MEDIA_FILE_EXTENSION);
+    }
+
+    /**
+     * Entity class for photo content.
+     */
+    private static class PhotoContent {
+        public long id;
+        public long taken;
+        public int size;
+    }
+}

--- a/laevatein/src/main/java/com/laevatein/internal/utils/MediaStoreUtils.java
+++ b/laevatein/src/main/java/com/laevatein/internal/utils/MediaStoreUtils.java
@@ -15,7 +15,10 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.Handler;
 import android.provider.MediaStore;
+import android.support.v4.content.FileProvider;
 import android.util.Log;
+
+import com.laevatein.R;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -87,12 +90,12 @@ public class MediaStoreUtils {
     public String invokeCameraCapture(Activity activity, int requestCode) {
         if (!hasCameraFeature(mContext)) return null;
 
-        File toSave = getOutputFileUri();
+        File toSave = getOutputFile();
         if (toSave == null) return null;
 
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         intent.addCategory(Intent.CATEGORY_DEFAULT);
-        intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(toSave));
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, FileProvider.getUriForFile(activity, activity.getString(R.string.l_file_provider_authorities), toSave));
         intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, 1);
         activity.startActivityForResult(intent, requestCode);
         return toSave.toString();
@@ -314,7 +317,7 @@ public class MediaStoreUtils {
      * @return a file
      */
     @TargetApi(Build.VERSION_CODES.FROYO)
-    private File getOutputFileUri() {
+    private File getOutputFile() {
         File extDir = new File(
                 Environment.getExternalStoragePublicDirectory(
                         Environment.DIRECTORY_PICTURES),

--- a/laevatein/src/main/java/com/laevatein/internal/utils/MediaStoreUtils.java
+++ b/laevatein/src/main/java/com/laevatein/internal/utils/MediaStoreUtils.java
@@ -15,6 +15,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.Handler;
 import android.provider.MediaStore;
+import android.support.media.ExifInterface;
 import android.support.v4.content.FileProvider;
 import android.util.Log;
 
@@ -242,8 +243,7 @@ public class MediaStoreUtils {
             values.put(MediaStore.Images.Media.TITLE, file.getName());
             values.put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg");
             values.put(MediaStore.Images.Media.DESCRIPTION, "mixi Photo");
-            values.put(MediaStore.Images.Media.ORIENTATION,
-                    ExifInterfaceUtils.getExifOrientation(file.getAbsolutePath()));
+            values.put(MediaStore.Images.Media.ORIENTATION, new ExifInterface(file.getAbsolutePath()).getRotationDegrees());
             long date = ExifInterfaceUtils.getExifDateTimeInMillis(file.getAbsolutePath());
             if (date != -1)
                 values.put(MediaStore.Images.Media.DATE_TAKEN, date);

--- a/laevatein/src/main/java/com/laevatein/ui/PhotoSelectionActivity.java
+++ b/laevatein/src/main/java/com/laevatein/ui/PhotoSelectionActivity.java
@@ -45,10 +45,10 @@ import com.laevatein.internal.ui.helper.PhotoSelectionActivityDrawerToggle;
 import com.laevatein.internal.ui.helper.PhotoSelectionViewHelper;
 import com.laevatein.internal.ui.helper.options.PhotoSelectionOptionsMenu;
 import com.laevatein.internal.utils.ErrorViewUtils;
+import com.laevatein.internal.utils.MediaStoreUtils;
 
 import java.util.ArrayList;
 
-import jp.mixi.compatibility.android.provider.MediaStoreCompat;
 
 /**
  * @author KeithYokoma
@@ -69,7 +69,7 @@ public class PhotoSelectionActivity extends AppCompatActivity implements
     public static final int REQUEST_CODE_CAPTURE = 1;
     public static final int REQUEST_CODE_PREVIEW = 2;
     private final SelectedUriCollection mCollection = new SelectedUriCollection(this);
-    private MediaStoreCompat mMediaStoreCompat;
+    private MediaStoreUtils mMediaStoreUtils;
     private PhotoSelectionActivityDrawerToggle mToggle;
     private DrawerLayout mDrawer;
     private String mCapturePhotoUriHolder;
@@ -82,7 +82,7 @@ public class PhotoSelectionActivity extends AppCompatActivity implements
         setContentView(R.layout.l_activity_select_photo);
         PhotoSelectionViewHelper.setUpActivity(this);
         PhotoSelectionViewHelper.setUpCounter(this);
-        mMediaStoreCompat = new MediaStoreCompat(this, HandlerUtils.getMainHandler());
+        mMediaStoreUtils = new MediaStoreUtils(this, HandlerUtils.getMainHandler());
         mCapturePhotoUriHolder = savedInstanceState != null ? savedInstanceState.getString(STATE_CAPTURE_PHOTO_URI) : "";
         mCollection.onCreate(savedInstanceState);
         mCollection.prepareSelectionSpec(getIntent().<SelectionSpec>getParcelableExtra(EXTRA_SELECTION_SPEC));
@@ -116,7 +116,7 @@ public class PhotoSelectionActivity extends AppCompatActivity implements
 
     @Override
     protected void onDestroy() {
-        mMediaStoreCompat.destroy();
+        mMediaStoreUtils.destroy();
         super.onDestroy();
     }
 
@@ -125,10 +125,10 @@ public class PhotoSelectionActivity extends AppCompatActivity implements
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == REQUEST_CODE_CAPTURE && resultCode == Activity.RESULT_OK) {
-            Uri captured = mMediaStoreCompat.getCapturedPhotoUri(data, mCapturePhotoUriHolder);
+            Uri captured = mMediaStoreUtils.getCapturedPhotoUri(data, mCapturePhotoUriHolder);
             if (captured != null) {
                 mCollection.add(captured);
-                mMediaStoreCompat.cleanUp(mCapturePhotoUriHolder);
+                mMediaStoreUtils.cleanUp(mCapturePhotoUriHolder);
             }
             supportInvalidateOptionsMenu();
         } else if (requestCode == REQUEST_CODE_PREVIEW && resultCode == Activity.RESULT_OK) {
@@ -186,8 +186,8 @@ public class PhotoSelectionActivity extends AppCompatActivity implements
         return mCollection;
     }
 
-    public final MediaStoreCompat getMediaStoreCompat() {
-        return mMediaStoreCompat;
+    public final MediaStoreUtils getMediaStoreUtils() {
+        return mMediaStoreUtils;
     }
 
     public final void prepareCapture(String uri) {

--- a/laevatein/src/main/res/values/strings.xml
+++ b/laevatein/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="l_detail_photo_title">Photo Detail</string>
 
     <string name="l_content_transition_name">ContentsTransition</string>
+    <string name="l_file_provider_authorities">com.laevatein.fileprovider</string>
 </resources>

--- a/laevatein/src/main/res/xml/file_paths.xml
+++ b/laevatein/src/main/res/xml/file_paths.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<paths>
+    <external-path
+        name="pictures"
+        path="Pictures" />
+</paths>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,8 +22,8 @@ android {
 ext.supportLibraryVersion = '27.1.0'
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
-    implementation "com.android.support:support-v4:$supportLibraryVersion"
+    implementation "com.android.support:appcompat-v7:${supportLibraryVersion}"
+    implementation "com.android.support:support-v4:${supportLibraryVersion}"
     implementation project(':laevatein')
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 14

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion "26.0.3"
 
     defaultConfig {
@@ -19,8 +19,11 @@ android {
     }
 }
 
+ext.supportLibraryVersion = '27.1.0'
+
 dependencies {
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support:support-v4:$supportLibraryVersion"
     implementation project(':laevatein')
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 


### PR DESCRIPTION
## Overview
- resolve #80

## Approach

Deleted [Android-Device-Compatibility](https://github.com/mixi-inc/Android-Device-Compatibility)
- Implementation of this library was causing the crash

Some source code has been diverted and replaced from Android-Device-Compatibility
- Implemented [ExifInterfaceCompat](https://github.com/mixi-inc/Android-Device-Compatibility/blob/master/AndroidDeviceCompatibility/src/main/java/jp/mixi/compatibility/android/media/ExifInterfaceCompat.java) as `ExifInterfaceUtils`
- Implemented [MediaStoreCompat](https://github.com/mixi-inc/Android-Device-Compatibility/blob/master/AndroidDeviceCompatibility/src/main/java/jp/mixi/compatibility/android/provider/MediaStoreCompat.java) as `MediaStoreUtils`

Fixed the implementation of MediaStoreCompat (MediaStoreUtils)
- Set the destination of `MediaStore.EXTRA_OUTPUT` to the URI generated by FileProvider

Fixed the implementation of ExifInterfaceCompat (ExifInterfaceUtils)
- Use ExifInterface of support library